### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    @items = Item.all.order('created_at DESC')
+    @items = Item.order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
   
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
-  
+
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new
@@ -21,6 +21,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:product_name, :product_info, :price, :category_id, :condition_id, :postage_type_id,:prefectures_id, :delivery_days_id, :image).merge(user_id: current_user.id)
+    params.require(:item).permit(:product_name, :product_info, :price, :category_id, :condition_id, :postage_type_id,
+                                 :prefectures_id, :delivery_days_id, :image).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
   
   def index
-    @items = Item.all
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,18 +3,18 @@ class Item < ApplicationRecord
   has_one_attached :image
 
   extend ActiveHash::Associations::ActiveRecordExtensions
-    belongs_to :category
-    belongs_to :condition
-    belongs_to :postage_type
-    belongs_to :prefectures
-    belongs_to :delivery_days
-    
-    with_options presence: true do
-      validates :image
-      validates :product_name
-      validates :product_info
-      validates :price, numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
-    end
+  belongs_to :category
+  belongs_to :condition
+  belongs_to :postage_type
+  belongs_to :prefectures
+  belongs_to :delivery_days
+
+  with_options presence: true do
+    validates :image
+    validates :product_name
+    validates :product_info
+    validates :price, numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
+  end
 
   with_options presence: true, numericality: { other_than: 1, message: 'を選択してください' } do
     validates :category_id

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,9 +130,9 @@
 
      
       <% unless @items.blank? %>
-        <li class='list'>
-          <%= link_to "#" do %>
-            <% @items.each do |item| %>
+        <% @items.each do |item| %>
+          <li class='list'>
+            <%= link_to "#" do %>
               <div class='item-img-content'>
                 <%= image_tag item.image, class: "item-img" %>
                 <%# 商品が売れていればsold outを表示しましょう %>
@@ -154,8 +154,8 @@
                 </div>
               </div>
             <% end %>
-          <% end %>
-        </li>
+          </li>
+        <% end %>
       <% end %>
    
       <% if @items.blank? %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,37 +128,37 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+     
+      <% unless @items.blank? %>
+        <li class='list'>
+          <%= link_to "#" do %>
+            <% @items.each do |item| %>
+              <div class='item-img-content'>
+                <%= image_tag item.image, class: "item-img" %>
+                <%# 商品が売れていればsold outを表示しましょう %>
+                <%# <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div> %>
+                <%# //商品が売れていればsold outを表示しましょう %>
+              </div>
+              <div class='item-info'>
+                <h3 class='item-name'>
+                  <%= item.product_name %>
+                </h3>
+                <div class='item-price'>
+                  <span><%= item.price %>円<br><%= item.postage_type.name %></span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          <% end %>
+        </li>
+      <% end %>
+   
+      <% if @items.blank? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -175,9 +175,9 @@
           </div>
         </div>
         <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      </li> 
+      <% end %>
+
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,14 +3,14 @@ FactoryBot.define do
     transient do
       person { Gimei.name }
     end
-      family_name { person.last.kanji }
-      first_name { person.first.kanji }
-      read_family { person.last.katakana }
-      read_first { person.first.katakana }
-      nickname { Faker::Name.name }
-      birthday { Faker::Date.backward }
-      email { Faker::Internet.free_email }
-      password { '123abc' }
-      password_confirmation { password }
+    family_name { person.last.kanji }
+    first_name { person.first.kanji }
+    read_family { person.last.katakana }
+    read_first { person.first.katakana }
+    nickname { Faker::Name.name }
+    birthday { Faker::Date.backward }
+    email { Faker::Internet.free_email }
+    password { '123abc' }
+    password_confirmation { password }
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -13,49 +13,49 @@ RSpec.describe Item, type: :model do
     end
     context '商品が出品できない場合' do
       it 'product_nameがないと出品できない' do
-        @item.product_name = ""
+        @item.product_name = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Product name can't be blank") 
+        expect(@item.errors.full_messages).to include("Product name can't be blank")
       end
       it 'product_infoがないと出品できない' do
-        @item.product_info = ""
+        @item.product_info = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Product info can't be blank") 
+        expect(@item.errors.full_messages).to include("Product info can't be blank")
       end
       it 'category_idがないと出品できない' do
         @item.category_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category を選択してください") 
+        expect(@item.errors.full_messages).to include('Category を選択してください')
       end
       it 'condition_idがないと出品できない' do
         @item.condition_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Condition を選択してください") 
+        expect(@item.errors.full_messages).to include('Condition を選択してください')
       end
       it 'postage_type_idがないと出品できない' do
         @item.postage_type_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Postage type を選択してください") 
+        expect(@item.errors.full_messages).to include('Postage type を選択してください')
       end
       it 'prefectures_idがないと出品できない' do
         @item.prefectures_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefectures を選択してください") 
+        expect(@item.errors.full_messages).to include('Prefectures を選択してください')
       end
       it 'delivery_days_idがないと出品できない' do
         @item.delivery_days_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery days を選択してください") 
+        expect(@item.errors.full_messages).to include('Delivery days を選択してください')
       end
       it 'priceがないと出品できない' do
-        @item.price = ""
+        @item.price = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price can't be blank") 
+        expect(@item.errors.full_messages).to include("Price can't be blank")
       end
       it 'imageがないと出品できない' do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Image can't be blank") 
+        expect(@item.errors.full_messages).to include("Image can't be blank")
       end
       it 'ユーザーが紐付いていなければ投稿できない' do
         @item.user = nil
@@ -65,67 +65,53 @@ RSpec.describe Item, type: :model do
       it 'カテゴリーに「---」が選択されている場合は出品できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category を選択してください") 
+        expect(@item.errors.full_messages).to include('Category を選択してください')
       end
       it '商品の状態に「---」が選択されている場合は出品できない' do
         @item.condition_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Condition を選択してください") 
-        
+        expect(@item.errors.full_messages).to include('Condition を選択してください')
       end
       it '配送料の負担に「---」が選択されている場合は出品できない' do
         @item.postage_type_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Postage type を選択してください") 
-        
+        expect(@item.errors.full_messages).to include('Postage type を選択してください')
       end
       it '発送元の地域に「---」が選択されている場合は出品できない' do
         @item.prefectures_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefectures を選択してください") 
-        
+        expect(@item.errors.full_messages).to include('Prefectures を選択してください')
       end
       it '発送までの日数に「---」が選択されている場合は出品できない' do
         @item.delivery_days_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery days を選択してください") 
+        expect(@item.errors.full_messages).to include('Delivery days を選択してください')
       end
       it '価格が全角数字では出品できない' do
-        @item.price = "１２３４５"
+        @item.price = '１２３４５'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it '半角英数混合では出品できない' do
-        @item.price = "123abc"
+        @item.price = '123abc'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it '半角英語だけでは出品できない' do
-        @item.price = "abcdef"
+        @item.price = 'abcdef'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it '価格が300円未満では出品できない' do
         @item.price = 200
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be greater than or equal to 300") 
+        expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
       end
       it '価格が9_999_999円を超えると出品できない' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be less than or equal to 9999999") 
-
+        expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
       end
-      
-
-
-
-
-
-
-
-
-
     end
   end
 end


### PR DESCRIPTION
 # What
商品一覧表示機能の実装


 # Why

投稿した全ての商品が一覧で表示されるようにitems#indexアクションを設定しました。

機能実装後の画像
（商品投稿がない時）
https://gyazo.com/bef23caac85ccd685416e1c1d7185eba

（商品投稿がある時）
https://gyazo.com/3f2340d6acc29c883c530f991037d923