### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.order('created_at DESC')

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,10 +17,10 @@ class ItemsController < ApplicationController
       render :new
     end
   end
+
   def show
     @item = Item.find(params[:id])
   end
-  
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,6 +17,10 @@ class ItemsController < ApplicationController
       render :new
     end
   end
+  def show
+    @item = Item.find(params[:id])
+  end
+  
 
   private
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,7 @@
 class Item < ApplicationRecord
   belongs_to :user
   has_one_attached :image
+  has_one :purchase_info
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :category

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,7 @@
 class Item < ApplicationRecord
   belongs_to :user
   has_one_attached :image
-  has_one :purchase_info
+  # has_one :purchase_info
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :category

--- a/app/models/purchase_info.rb
+++ b/app/models/purchase_info.rb
@@ -1,4 +1,4 @@
 class PurchaseInfo < ApplicationRecord
-  belongs_to :user
-  belongs_to :item
+  # belongs_to :user
+  # belongs_to :item
 end

--- a/app/models/purchase_info.rb
+++ b/app/models/purchase_info.rb
@@ -1,0 +1,4 @@
+class PurchaseInfo < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,5 +19,5 @@ class User < ApplicationRecord
   validates :password, format: { with: PASSWORD_REGEX, message: '英字と数字の両方を含めて設定してください' }
 
   has_many :items
-  has_many :purchase_infos
+  # has_many :purchase_infos
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,4 +19,5 @@ class User < ApplicationRecord
   validates :password, format: { with: PASSWORD_REGEX, message: '英字と数字の両方を含めて設定してください' }
 
   has_many :items
+  has_many :purchase_infos
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,7 +132,7 @@
       <% unless @items.blank? %>
         <% @items.each do |item| %>
           <li class='list'>
-            <%= link_to "#" do %>
+            <%= link_to item_path(item.id), method: :get do %>
               <div class='item-img-content'>
                 <%= image_tag item.image, class: "item-img" %>
                 <%# 商品が売れていればsold outを表示しましょう %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -135,11 +135,11 @@
             <%= link_to item_path(item.id), method: :get do %>
               <div class='item-img-content'>
                 <%= image_tag item.image, class: "item-img" %>
-                <%# 商品が売れていればsold outを表示しましょう %>
-                <%# <div class='sold-out'>
+                <% unless item.purchase_info.blank? %>
+                <div class='sold-out'>
                   <span>Sold Out!!</span>
-                </div> %>
-                <%# //商品が売れていればsold outを表示しましょう %>
+                </div>
+                <% end %>
               </div>
               <div class='item-info'>
                 <h3 class='item-name'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -135,11 +135,11 @@
             <%= link_to item_path(item.id), method: :get do %>
               <div class='item-img-content'>
                 <%= image_tag item.image, class: "item-img" %>
-                <% unless item.purchase_info.blank? %>
+                <%# <% unless item.purchase_info.blank? %> %>
                 <div class='sold-out'>
                   <span>Sold Out!!</span>
                 </div>
-                <% end %>
+                <%# <% end %> %>
               </div>
               <div class='item-info'>
                 <h3 class='item-name'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -135,11 +135,11 @@
             <%= link_to item_path(item.id), method: :get do %>
               <div class='item-img-content'>
                 <%= image_tag item.image, class: "item-img" %>
-                <%# <% unless item.purchase_info.blank? %> %>
+                <%# <% unless item.purchase_info.blank? %>
                 <div class='sold-out'>
                   <span>Sold Out!!</span>
                 </div>
-                <%# <% end %> %>
+                <%# <% end %>
               </div>
               <div class='item-info'>
                 <h3 class='item-name'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# <% unless @item.purchase_info.blank? %> %>
+      <%# <% unless @item.purchase_info.blank? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <%# <% end %> %>
+      <%# <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,9 +9,11 @@
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <% unless @item.purchase_info.blank? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
+      <% end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
@@ -24,19 +26,20 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if user_signed_in? && @item.purchase_info.blank? %>
+        <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+          <% if current_user.id == @item.user_id %>
+            <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+            <p class="or-text">or</p>
+            <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+          <% else %>
+            <%# 商品が売れていない場合はこちらを表示しましょう %>
+            <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+            <%# //商品が売れていない場合はこちらを表示しましょう %>
+          <% end %>
+        <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% end %>
+    
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
     </div>
@@ -103,9 +106,8 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
+  
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,13 +8,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
       <% unless @item.purchase_info.blank? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
       <% end %>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -27,17 +25,13 @@
     </div>
 
     <% if user_signed_in? && @item.purchase_info.blank? %>
-        <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
           <% if current_user.id == @item.user_id %>
             <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
             <p class="or-text">or</p>
             <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
           <% else %>
-            <%# 商品が売れていない場合はこちらを表示しましょう %>
             <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-            <%# //商品が売れていない場合はこちらを表示しましょう %>
           <% end %>
-        <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% end %>
     
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.product_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,10 +16,11 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ 
+        <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.postage_type.name %>
       </span>
     </div>
 
@@ -43,27 +44,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.postage_type.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefectures.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delivery_days.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <% unless @item.purchase_info.blank? %>
+      <%# <% unless @item.purchase_info.blank? %> %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <% end %>
+      <%# <% end %> %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -24,7 +24,7 @@
       </span>
     </div>
 
-    <% if user_signed_in? && @item.purchase_info.blank? %>
+    <% if user_signed_in? # && @item.purchase_info.blank? %>
           <% if current_user.id == @item.user_id %>
             <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
             <p class="or-text">or</p>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -35,7 +35,7 @@
     <% end %>
     
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.product_info %></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,8 @@ Rails.application.routes.draw do
   
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show] do
+    resources :purchase_info, only: [:create]
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
   resources :items, only: [:index, :new, :create, :show] do
-    resources :purchase_info, only: [:create]
+    # resources :purchase_info, only: [:create]
   end
 
 end

--- a/db/migrate/20210829115412_create_purchase_infos.rb
+++ b/db/migrate/20210829115412_create_purchase_infos.rb
@@ -1,0 +1,9 @@
+class CreatePurchaseInfos < ActiveRecord::Migration[6.0]
+  def change
+    create_table :purchase_infos do |t|
+      t.references :user,  null: false, foreign_key: true
+      t.references :item,  null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_19_122431) do
+ActiveRecord::Schema.define(version: 2021_08_29_115412) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -48,6 +48,15 @@ ActiveRecord::Schema.define(version: 2021_08_19_122431) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "purchase_infos", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_purchase_infos_on_item_id"
+    t.index ["user_id"], name: "index_purchase_infos_on_user_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "family_name", default: "", null: false
     t.string "first_name", default: "", null: false
@@ -68,4 +77,6 @@ ActiveRecord::Schema.define(version: 2021_08_19_122431) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "purchase_infos", "items"
+  add_foreign_key "purchase_infos", "users"
 end

--- a/spec/factories/purchase_infos.rb
+++ b/spec/factories/purchase_infos.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :purchase_info do
+    
+  end
+end

--- a/spec/factories/purchase_infos.rb
+++ b/spec/factories/purchase_infos.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :purchase_info do
-    
   end
 end

--- a/spec/models/purchase_info_spec.rb
+++ b/spec/models/purchase_info_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe PurchaseInfo, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
 # What
商品詳細表示機能の実装

# Why
item#indexの商品表示箇所のリンクにパスを渡し、一つ一つの商品詳細ページへ遷移するよう実装しました。また、売却済商品を区別するためのPurchase＿infoモデルを生成し、売却済の商品に対してsold outの表示ができるようにしました。

ログイン状態の出品者が、自身の出品した販売中商品の詳細ページへ遷移した動画
https://gyazo.com/b8b41aa9285f0d57d719cfa85819a665

ログイン状態の出品者が、自身の出品した売却済み商品の詳細ページへ遷移した動画
https://gyazo.com/95b071600870992be78658869a89d320

ログイン状態の出品者以外のユーザーが、他者の出品した販売中商品の詳細ページへ遷移した動画
https://gyazo.com/789a48d472911f3d8cc758a255a9d6ea

ログイン状態の出品者以外のユーザーが、他者の出品した売却済み商品の詳細ページへ遷移した動画
https://gyazo.com/f03adb374b0a4f179581ad4f88dad067

ログアウト状態のユーザーが、商品詳細ページへ遷移した動画
https://gyazo.com/ae1f085ab486fa815fd3640ed5439913

宜しくお願いします。