### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:edit, :update, :show]
+  before_action :set_item, only: [:edit, :update, :show, :destroy]
   
   def index
     @items = Item.order('created_at DESC')
@@ -35,6 +35,12 @@ class ItemsController < ApplicationController
       render :edit
     end
   end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
+  end
+  
   
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,7 @@
 class Item < ApplicationRecord
   belongs_to :user
-  has_one_attached :image
-  # has_one :purchase_info
+  has_one_attached :image, dependent: :destroy 
+  has_one :purchase_info, dependent: :destroy 
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :category

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
           <% if current_user.id == @item.user_id %>
             <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
             <p class="or-text">or</p>
-            <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+            <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
           <% else %>
             <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy] do
+  resources :items do
     # resources :purchase_info, only: [:create]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show, :edit, :update] do
+  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy] do
     # resources :purchase_info, only: [:create]
   end
 end


### PR DESCRIPTION
 # What

商品削除機能の実装

 # Why

削除は出品者本人のみにできて、商品の削除と共に画像と購入情報も一緒に削除されるよう記述しました。
商品購入機能の実装はまだですが、購入情報のデータベースを作成した際のマイグレーションファイルが存在するため、アソシエーションと ` dependent: :destroy  ` を記述しました。

- ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/efd4e76a924092df983e9497c8f94f0c